### PR TITLE
fix: allow Ctrl+D to exit when prompt is empty

### DIFF
--- a/wingman/app.py
+++ b/wingman/app.py
@@ -286,6 +286,7 @@ class WingmanApp(App):
         Binding("ctrl+b", "background", "Background"),
         Binding("ctrl+z", "undo", "Undo"),
         Binding("ctrl+c", "quit", "Quit"),
+        Binding("ctrl+d", "exit_if_empty", "Quit", priority=True, show=False),
         Binding("ctrl+q", "quit", "Quit", show=False),
         Binding("f1", "help", "Help"),
         # Split panel controls
@@ -1338,6 +1339,12 @@ class WingmanApp(App):
             self._show_info(f"[#9ece6a]Restored {len(restored)} file(s) from {checkpoint.id}:[/]\n" + "\n".join(f"  • {f}" for f in restored))
         else:
             self._show_info("[#f7768e]Failed to restore checkpoint[/]")
+
+    def action_exit_if_empty(self) -> None:
+        """Exit the app on Ctrl+D when the active input has no text."""
+        focused = self.screen.focused
+        if isinstance(focused, Input) and not (focused.value or "").strip():
+            self.exit()
 
     def action_help(self) -> None:
         bg_count = len(get_background_processes())


### PR DESCRIPTION
Added a Ctrl+D shortcut that quits only when the chat input is empty. This mirrors the behavior of most Unix console utilities (EOF, End of File) and coding tools (e.g., Claude Code, Codex), where Ctrl+D ends input gracefully when there’s nothing typed.