### PR TITLE
style: fix ruff linting errors in src/wingman/

### DIFF
--- a/src/wingman/config.py
+++ b/src/wingman/config.py
@@ -1,5 +1,6 @@
 """Configuration and constants."""
 
+import contextlib
 import json
 from importlib.metadata import version
 from pathlib import Path
@@ -107,10 +108,8 @@ def save_api_key(api_key: str) -> None:
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     config = {}
     if CONFIG_FILE.exists():
-        try:
+        with contextlib.suppress(Exception):
             config = json.loads(CONFIG_FILE.read_text())
-        except Exception:
-            pass
     config["api_key"] = api_key
     CONFIG_FILE.write_text(json.dumps(config, indent=2))
 

--- a/src/wingman/memory.py
+++ b/src/wingman/memory.py
@@ -29,10 +29,7 @@ def save_memory(content: str) -> None:
 def append_memory(text: str) -> None:
     """Append to project memory."""
     current = load_memory()
-    if current:
-        new_content = current + "\n\n" + text
-    else:
-        new_content = text
+    new_content = current + "\n\n" + text if current else text
     save_memory(new_content)
 
 

--- a/src/wingman/sessions.py
+++ b/src/wingman/sessions.py
@@ -1,7 +1,6 @@
 """Session storage and persistence."""
 
 import json
-from pathlib import Path
 
 from .config import SESSIONS_DIR
 

--- a/src/wingman/tools.py
+++ b/src/wingman/tools.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .checkpoints import get_checkpoint_manager, get_current_session
+from .checkpoints import get_checkpoint_manager
 
 # App instance reference (set by app module, avoids circular import)
 _app_instance: Any = None
@@ -303,7 +303,7 @@ def _edit_file_impl(
             _track_tool_call(command, output, "error", panel_id)
             return output
         if content.count(old_string) > 1:
-            output = f"Error: old_string appears multiple times. Be more specific."
+            output = "Error: old_string appears multiple times. Be more specific."
             _notify_status(widget_id, "error", panel_id=panel_id)
             _track_tool_call(command, output, "error", panel_id)
             return output
@@ -361,9 +361,7 @@ def _list_files_sync(pattern: str, base: Path, working_dir: Path) -> list[str]:
     }
     results = []
     max_files = 5000
-    checked = 0
-    for p in base.glob(pattern):
-        checked += 1
+    for checked, p in enumerate(base.glob(pattern), 1):
         if checked > max_files:
             break
         if p.is_file() and not any(part in ignore for part in p.parts):
@@ -390,7 +388,7 @@ async def _list_files_impl(pattern: str, path: str, working_dir: Path, panel_id:
         output = "Timed out after 15s"
         await _update_command_status(widget_id, "error", output, panel_id)
         _track_tool_call(command, output, "error", panel_id)
-        return f"Listing timed out after 15s. Try a more specific pattern."
+        return "Listing timed out after 15s. Try a more specific pattern."
     except Exception as e:
         output = str(e)
         await _update_command_status(widget_id, "error", output, panel_id)
@@ -470,7 +468,7 @@ async def _search_files_impl(
         output = "Timed out after 30s"
         await _update_command_status(widget_id, "error", output, panel_id)
         _track_tool_call(command, output, "error", panel_id)
-        return f"Search timed out after 30s. Try a more specific path or pattern."
+        return "Search timed out after 30s. Try a more specific path or pattern."
     except re.error as e:
         output = f"Invalid regex: {e}"
         await _update_command_status(widget_id, "error", output, panel_id)

--- a/src/wingman/ui/modals.py
+++ b/src/wingman/ui/modals.py
@@ -2,14 +2,13 @@
 
 import difflib
 
+from dedalus_labs import AsyncDedalus
 from rich.text import Text
 from textual import on, work
 from textual.binding import Binding
 from textual.containers import Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Input, Label, ListItem, ListView, Static
-
-from dedalus_labs import AsyncDedalus
 
 from ..config import save_api_key
 
@@ -327,7 +326,7 @@ class DiffModal(ModalScreen[bool]):
 
         with Vertical():
             with Vertical(classes="header"):
-                yield Static(Text.from_markup(f"[bold #7aa2f7]Pending Edit[/]"))
+                yield Static(Text.from_markup("[bold #7aa2f7]Pending Edit[/]"))
                 yield Static(Text.from_markup(f"[#565f89]{display_path}[/]"), classes="filepath")
             yield Static(Text.from_markup(diff_text), classes="diff-view")
             yield Static(

--- a/src/wingman/ui/widgets.py
+++ b/src/wingman/ui/widgets.py
@@ -1,5 +1,6 @@
 """UI widgets for chat interface."""
 
+import contextlib
 import random
 import time
 from pathlib import Path
@@ -298,7 +299,7 @@ class CommandStatus(Static):
 
         # Add output preview if available
         if self._output and self._status in ("success", "error"):
-            lines = [l for l in self._output.strip().split("\n") if l.strip()]
+            lines = [line for line in self._output.strip().split("\n") if line.strip()]
             if lines:
                 preview_lines = []
                 for line in lines[: self.MAX_OUTPUT_LINES]:
@@ -373,10 +374,8 @@ class ChatPanel(Vertical):
         self._is_active = active
         self.set_class(active, "active-panel")
         if active:
-            try:
+            with contextlib.suppress(Exception):
                 self.query_one(f"#{self.panel_id}-prompt", Input).focus()
-            except Exception:
-                pass
 
     def get_chat_container(self) -> Vertical:
         return self.query_one(f"#{self.panel_id}-chat", Vertical)


### PR DESCRIPTION
## Description

 Fixed linting errors in `src/wingman/` directory from PR #6.

## Details
- Organized and cleaned up imports (removed unused imports)
- Removed unnecessary f-string prefixes  
- Simplified code structure (combined nested ifs, replaced try-except-pass with contextlib.suppress)
- Used more pythonic patterns (enumerate instead of manual counter, ternary operators)
- Fixed ambiguous variable name (`l` → `line`)

All changes are **style-only** and preserve existing behavior. No logic changes.

```bash
✅ uv run ruff check src/wingman/     # All checks passed!
✅ uv run ruff format --check src/wingman/  # 15 files already formatted
```

## Type of Change

- [x] Refactoring (no functional changes)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have tested the TUI locally