### PR TITLE
feat: add elapsed timer, input padding, and message separators

### DIFF
--- a/src/wingman/ui/app.tcss
+++ b/src/wingman/ui/app.tcss
@@ -88,6 +88,11 @@ StreamingText {
     margin: 0 0 1 0;
 }
 
+.message-separator {
+    height: auto;
+    margin: 1 0;
+}
+
 .hidden {
     display: none;
 }
@@ -220,6 +225,7 @@ ChatPanel.active-panel {
 .panel-prompt {
     background: #24283b;
     border: none;
+    padding: 1 2;
 }
 
 .panel-hint {


### PR DESCRIPTION
## Summary
   UI polish improvements for better user experience:
   - **Elapsed timer**: Shows generation time with interrupt hint (e.g., `3s · esc to interrupt`)
   - **Input padding**: Added padding to input box for better readability
   - **Message separators**: Subtle separator line between responses and new user input
   - **Interrupt message**: Shows "Interrupted by the user" when pressing Esc
   - **Cleanup**: Removed unused `action_stop_generation` method
   ## Screenshots
<img width="437" height="87" alt="Screenshot 2026-01-09 at 11 07 14 PM" src="https://github.com/user-attachments/assets/9727714b-516d-4c65-8c0f-fb3b7055ee3b" />
<img width="841" height="237" alt="Screenshot 2026-01-09 at 11 28 43 PM" src="https://github.com/user-attachments/assets/ce2b1ff1-b8cc-4800-be82-4d81480e6bf1" />

