### PR TITLE
feat: add command dropdown with arrow key navigation

### DIFF
--- a/src/wingman/command_completion.py
+++ b/src/wingman/command_completion.py
@@ -175,6 +175,41 @@ def get_hint_candidates(
     return []
 
 
+def get_hint_candidates_with_desc(
+    value: str,
+    cursor_position: int | None = None,
+) -> list[tuple[str, str]]:
+    """Get command hint candidates with descriptions for the current input.
+
+    Args:
+        value: Current input value.
+        cursor_position: Optional cursor position, defaults to end of input.
+
+    Returns:
+        List of (command, description) tuples for display.
+    """
+    if cursor_position is None:
+        cursor_position = len(value)
+    context = _parse_context(value, cursor_position)
+    if context is None:
+        return []
+
+    if context.active_index == 0:
+        search = context.active.text[1:] if context.active.text.startswith("/") else context.active.text
+        search_lower = search.lower()
+        matches = [
+            (cmd.lstrip("/"), desc)
+            for cmd, desc in COMMANDS
+            if search_lower in cmd.lower() or search_lower in desc.lower()
+        ]
+        if len(matches) == 1 and matches[0][0] == search:
+            return []
+        return matches
+
+    # For non-command hints (options, etc.), return empty descriptions
+    return []
+
+
 @dataclass(frozen=True)
 class _CompletionContext:
     value: str

--- a/src/wingman/ui/app.tcss
+++ b/src/wingman/ui/app.tcss
@@ -213,7 +213,7 @@ ChatPanel.active-panel {
 .panel-input {
     height: auto;
     min-height: 3;
-    max-height: 8;
+    max-height: 20;
     padding: 0 1 1 1;
 }
 


### PR DESCRIPTION
## Summary

Replaces inline command hints with a vertical dropdown list for better discoverability and navigation.

### Features

- **Vertical dropdown**: Commands displayed in a vertical list instead of inline
- **Command descriptions**: Shows description next to each command (e.g., `/model` → "Switch model")
- **Arrow key navigation**: Use up/down arrows to navigate through suggestions
- **Selection**: Tab or Enter to select the highlighted command
- **Scrolling viewport**: Selection stays visible with "...N above" and "...+N more" indicators
- **10 visible items**: Shows up to 10 commands at a time

### Screenshot
<img width="838" height="322" alt="Screenshot 2026-01-09 at 11 48 20 PM" src="https://github.com/user-attachments/assets/f1ce239d-e75f-47de-b04b-96027b5653e2" />
<img width="850" height="337" alt="Screenshot 2026-01-09 at 11 52 55 PM" src="https://github.com/user-attachments/assets/ff895af1-b81f-4538-b214-af1a4638594e" />
