### PR TITLE
chore: add CLA and vouch contributor gates

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,27 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: iainmcgin/cla-github-action@eeb7f3ffa305b600c6e873578b9ea78ca11a5f3e  # v2.7.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-document: "https://github.com/${{ github.repository }}/blob/main/CLA.md"
+          path-to-signatures: "signatures/cla.json"
+          branch: "cla-signatures"
+          allowlist: "windsornguyen,aryanma,dependabot[bot],github-actions[bot],renovate[bot],mendral-app[bot]"

--- a/.github/workflows/vouch-check.yml
+++ b/.github/workflows/vouch-check.yml
@@ -1,0 +1,18 @@
+name: "Vouch: Check PR"
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mitchellh/vouch/action/setup-vouch@main
+      - uses: mitchellh/vouch/action/check-pr@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-close: true

--- a/.github/workflows/vouch-manage.yml
+++ b/.github/workflows/vouch-manage.yml
@@ -1,0 +1,18 @@
+name: "Vouch: Manage"
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  manage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mitchellh/vouch/action/setup-vouch@main
+      - uses: mitchellh/vouch/action/manage-by-issue@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,76 @@
+# Individual Contributor License Agreement ("Agreement") v1.0
+
+Thank you for your interest in Wingman (the "Project"), owned and managed
+by Dedalus Labs, Inc. (the "Maintainer"). To clarify the intellectual
+property license granted with Contributions from any person or entity, the
+Maintainer must have on file a signed Contributor License Agreement ("CLA")
+from each Contributor, indicating agreement with the license terms below.
+This agreement is for your protection as a Contributor as well as the
+protection of the Maintainer and its users. It does not change your rights
+to use your own Contributions for any other purpose.
+
+You accept and agree to the following terms and conditions for Your
+Contributions (present and future) that you submit to the Maintainer.
+Except for the license granted herein to the Maintainer and recipients of
+software distributed by the Maintainer, You reserve all right, title, and
+interest in and to Your Contributions.
+
+## 1. Definitions.
+
+"You" (or "Your") shall mean the copyright owner or legal entity authorized
+by the copyright owner that is making this Agreement with the Maintainer.
+
+"Contribution" shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally
+submitted by You to the Maintainer for inclusion in, or documentation of,
+any of the products owned or managed by the Maintainer (the "Work"). For
+the purposes of this definition, "submitted" means any form of electronic,
+verbal, or written communication sent to the Maintainer or its
+representatives, including but not limited to communication on electronic
+mailing lists, source code control systems, and issue tracking systems that
+are managed by, or on behalf of, the Maintainer for the purpose of
+discussing and improving the Work, but excluding communication that is
+conspicuously marked or otherwise designated in writing by You as "Not a
+Contribution."
+
+## 2. Grant of Copyright License.
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+the Maintainer and to recipients of software distributed by the Maintainer
+a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare derivative works of, publicly
+display, publicly perform, sublicense, and distribute Your Contributions
+and such derivative works.
+
+## 3. Grant of Patent License.
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+the Maintainer and to recipients of software distributed by the Maintainer
+a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made, use,
+offer to sell, sell, import, and otherwise transfer the Work, where such
+license applies only to those patent claims licensable by You that are
+necessarily infringed by Your Contribution(s) alone or by combination of
+Your Contribution(s) with the Work to which such Contribution(s) was
+submitted.
+
+## 4. Representations.
+
+You represent that you are legally entitled to grant the above license. If
+your employer(s) has rights to intellectual property that you create that
+includes your Contributions, you represent that you have received permission
+to make Contributions on behalf of that employer, that your employer has
+waived such rights for your Contributions to the Maintainer, or that your
+employer has executed a separate Corporate CLA with the Maintainer.
+
+You represent that each of Your Contributions is Your original creation.
+
+## 5. Support; Warranty Disclaimer.
+
+You are not expected to provide support for Your Contributions, except to
+the extent You desire to provide support. You may provide support for free,
+for a fee, or not at all. Unless required by applicable law or agreed to in
+writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including,
+without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.

--- a/VOUCHED.td
+++ b/VOUCHED.td
@@ -1,0 +1,6 @@
+# Maintainers and trusted contributors.
+# Format: one handle per line, sorted alphabetically, no @ prefix.
+# Prefix with platform: (e.g. github:user). Default platform is github.
+# Prefix with - to denounce. Append a reason after a space.
+github:aryanma
+github:windsornguyen


### PR DESCRIPTION
## Description

Adds two contributor gates for the open-source repo:

- **CLA**: On first PR, bot asks contributor to sign. Signatures stored on `cla-signatures` branch. Uses [iainmcgin/cla-github-action](https://github.com/iainmcgin/cla-github-action) (v2.7.1, pinned SHA).
- **Vouch**: Unvouched PRs auto-closed with explanation. Maintainers vouch via `vouch @user` on any issue. Uses [mitchellh/vouch](https://github.com/mitchellh/vouch).

Known committers (`windsornguyen`, `aryanma`) pre-vouched. Bots allowlisted in CLA config.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have tested the TUI locally

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dedalus-labs/codesmith/wingman/pr/24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->