### PR TITLE
chore: add column-align formatter and prek pre-commit hooks

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,7 @@
+[[repos]]
+repo = "local"
+hooks = [
+  { id = "align-fields", name = "Column-align fmt:off fields", entry = "python scripts/align-fields.py --check", language = "python", types = ["python"], pass_filenames = false },
+  { id = "ruff-check",   name = "Ruff lint",   entry = "uv run ruff check",          language = "system", types = ["python"] },
+  { id = "ruff-format",  name = "Ruff format",  entry = "uv run ruff format --check", language = "system", types = ["python"] },
+]

--- a/scripts/align-fields.py
+++ b/scripts/align-fields.py
@@ -1,132 +1,81 @@
 #!/usr/bin/env python3
-"""Align dataclass/enum fields inside ``# fmt: off`` blocks.
+"""Column-align dataclass and enum fields inside ``# fmt: off`` blocks.
 
 Scans Python files for ``# fmt: off`` / ``# fmt: on`` regions and
-column-aligns assignment lines so that field names, type annotations,
-default values, and inline comments line up.
+pads field names, type annotations, defaults, and inline comments
+into aligned columns.
 
-Usage:
-    scripts/align-fields.py                    # fix all src/ files in place
-    scripts/align-fields.py --check            # exit 1 if anything is misaligned
+Usage::
+
+    scripts/align-fields.py                       # fix all src/ files
+    scripts/align-fields.py --check               # exit 1 if misaligned
     scripts/align-fields.py src/wingman/tools.py  # fix specific files
-    scripts/align-fields.py --check src/       # check a directory
+
 """
 
 from __future__ import annotations
 
-import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-
-# Matches lines like:  name: type = default  # comment
-#   or:                 NAME = ("value", ...)
-FIELD_RE = re.compile(
-    r"^(?P<indent>\s+)"
-    r"(?P<name>\w+)"
-    r"(?P<colon>:\s*)?(?P<type>[^=#]+?)?"
-    r"(?P<eq>\s*=\s*)?"
-    r"(?P<default>.+?)?"
-    r"(?P<comment>\s*#\s*.+)?"
-    r"$"
-)
 
 MIN_GAP = 2
 
+SKIP_PREFIXES = ("#", "def ", "@", "class ", '"""', "'''", ")", "]", "}")
 
-def _is_field_line(line: str) -> bool:
-    """Heuristic: line is a dataclass field or enum member assignment."""
+
+# --- Data types ---
+
+
+@dataclass(frozen=True, slots=True)
+class Field:
+    """Parsed representation of one field line.
+
+    Covers both typed fields (``name: type = default``) and bare
+    assignments (``NAME = value``).
+
+    """
+
+    # fmt: off
+    indent:    str
+    name:      str
+    type_ann:  str
+    default:   str
+    comment:   str
+    has_colon: bool
+    # fmt: on
+
+
+# --- Parsing ---
+
+
+def is_field_line(line: str) -> bool:
+    """Test whether a line looks like a dataclass field or enum member.
+
+    Returns:
+        True if the line contains ``:`` or ``=`` and is not a comment,
+        decorator, class def, or continuation bracket.
+
+    """
     stripped = line.strip()
-    if not stripped or stripped.startswith("#") or stripped.startswith("def "):
+    if not stripped:
         return False
-    if stripped.startswith("@") or stripped.startswith("class "):
+    if any(stripped.startswith(p) for p in SKIP_PREFIXES):
         return False
-    if stripped.startswith(("\"\"\"", "'''", ")", "]", "}")):
-        return False
-    # Must have either `: type` or `= value`
     return ":" in stripped or "=" in stripped
 
 
-def _parse_field(line: str) -> dict | None:
-    """Parse a field line into parts for alignment."""
-    stripped = line.strip()
-    if not _is_field_line(line):
-        return None
+def find_top_level(s: str, target: str) -> int | None:
+    """Find the first occurrence of ``target`` outside strings and brackets.
 
-    indent = line[: len(line) - len(line.lstrip())]
+    Args:
+        s: Source string to scan.
+        target: Single character to find.
 
-    # Split off trailing inline comment
-    comment = ""
-    in_str = False
-    str_char = ""
-    paren_depth = 0
-    comment_start = -1
-    for i, ch in enumerate(stripped):
-        if in_str:
-            if ch == str_char and (i == 0 or stripped[i - 1] != "\\"):
-                in_str = False
-        elif ch in ('"', "'"):
-            in_str = True
-            str_char = ch
-        elif ch in ("(", "[", "{"):
-            paren_depth += 1
-        elif ch in (")", "]", "}"):
-            paren_depth -= 1
-        elif ch == "#" and paren_depth == 0:
-            comment_start = i
-            break
+    Returns:
+        Index of the first top-level occurrence, or None.
 
-    if comment_start >= 0:
-        comment = stripped[comment_start:]
-        stripped = stripped[:comment_start].rstrip()
-
-    # Parse name: type = default
-    if ":" in stripped:
-        colon_idx = stripped.index(":")
-        name = stripped[:colon_idx].strip()
-        rest = stripped[colon_idx + 1:].strip()
-
-        if "=" in rest:
-            # Find top-level `=` (not inside parens/brackets)
-            eq_idx = _find_top_level_eq(rest)
-            if eq_idx is not None:
-                type_ann = rest[:eq_idx].strip()
-                default = rest[eq_idx + 1:].strip()
-            else:
-                type_ann = rest
-                default = ""
-        else:
-            type_ann = rest
-            default = ""
-
-        return {
-            "indent": indent,
-            "name": name,
-            "type": type_ann,
-            "default": default,
-            "comment": comment,
-            "has_colon": True,
-        }
-
-    elif "=" in stripped:
-        eq_idx = _find_top_level_eq(stripped)
-        if eq_idx is None:
-            return None
-        name = stripped[:eq_idx].strip()
-        default = stripped[eq_idx + 1:].strip()
-        return {
-            "indent": indent,
-            "name": name,
-            "type": "",
-            "default": default,
-            "comment": comment,
-            "has_colon": False,
-        }
-
-    return None
-
-
-def _find_top_level_eq(s: str) -> int | None:
-    """Find the first `=` not inside parens/brackets/strings."""
+    """
     depth = 0
     in_str = False
     str_char = ""
@@ -134,116 +83,185 @@ def _find_top_level_eq(s: str) -> int | None:
         if in_str:
             if ch == str_char and (i == 0 or s[i - 1] != "\\"):
                 in_str = False
-        elif ch in ('"', "'"):
+            continue
+        if ch in ('"', "'"):
             in_str = True
             str_char = ch
         elif ch in ("(", "[", "{"):
             depth += 1
         elif ch in (")", "]", "}"):
             depth -= 1
-        elif ch == "=" and depth == 0:
-            # Skip == and !=
-            if i + 1 < len(s) and s[i + 1] == "=":
-                continue
-            if i > 0 and s[i - 1] in ("!", "<", ">"):
-                continue
+        elif ch == target and depth == 0:
+            if target == "=":
+                if i + 1 < len(s) and s[i + 1] == "=":
+                    continue
+                if i > 0 and s[i - 1] in ("!", "<", ">"):
+                    continue
             return i
     return None
 
 
-def _align_block(lines: list[str]) -> list[str]:
-    """Align a group of consecutive field lines."""
-    parsed = []
-    for line in lines:
-        p = _parse_field(line)
-        if p:
-            parsed.append(p)
-        else:
-            parsed.append(None)
+def split_comment(text: str) -> tuple[str, str]:
+    """Separate trailing inline comment from code.
 
-    fields = [p for p in parsed if p is not None]
+    Args:
+        text: Stripped line content (no leading whitespace).
+
+    Returns:
+        (code, comment) where comment includes the ``#``.
+
+    """
+    idx = find_top_level(text, "#")
+    if idx is None:
+        return text, ""
+    return text[:idx].rstrip(), text[idx:]
+
+
+def parse_field(line: str) -> Field | None:
+    """Parse a single line into a Field, or None if not a field.
+
+    Args:
+        line: Raw source line (may include trailing newline).
+
+    Returns:
+        Parsed Field or None if the line is not a field.
+
+    """
+    if not is_field_line(line):
+        return None
+
+    indent = line[: len(line) - len(line.lstrip())]
+    stripped = line.strip()
+    code, comment = split_comment(stripped)
+
+    if ":" in code:
+        colon = code.index(":")
+        name = code[:colon].strip()
+        rest = code[colon + 1 :].strip()
+
+        eq = find_top_level(rest, "=")
+        if eq is not None:
+            type_ann = rest[:eq].strip()
+            default = rest[eq + 1 :].strip()
+        else:
+            type_ann = rest
+            default = ""
+
+        return Field(indent, name, type_ann, default, comment, has_colon=True)
+
+    eq = find_top_level(code, "=")
+    if eq is None:
+        return None
+    name = code[:eq].strip()
+    default = code[eq + 1 :].strip()
+    return Field(indent, name, "", default, comment, has_colon=False)
+
+
+# --- Alignment ---
+
+
+def align_block(lines: list[str]) -> list[str]:
+    """Column-align a group of lines from a ``# fmt: off`` block.
+
+    Non-field lines (blank lines, class defs, decorators) pass through
+    unchanged. Field lines get padded so names, types, defaults, and
+    comments form clean columns.
+
+    Args:
+        lines: Source lines between ``# fmt: off`` and ``# fmt: on``.
+
+    Returns:
+        Aligned lines (same length as input).
+
+    """
+    parsed = [parse_field(line) for line in lines]
+    fields = [f for f in parsed if f is not None]
+
     if len(fields) < 2:
         return lines
 
-    has_types = any(f["has_colon"] for f in fields)
-    has_defaults = any(f["default"] for f in fields)
-    has_comments = any(f["comment"] for f in fields)
+    has_types = any(f.has_colon for f in fields)
+    has_defaults = any(f.default for f in fields)
+    has_comments = any(f.comment for f in fields)
 
-    # name+colon is one visual unit: "name:" then space then type
     if has_types:
-        max_name_col = max(len(f["name"]) + 1 for f in fields if f["has_colon"])
+        max_name_col = max(len(f.name) + 1 for f in fields if f.has_colon)
     else:
-        max_name_col = max(len(f["name"]) for f in fields)
-    max_type = max((len(f["type"]) for f in fields if f["type"]), default=0)
+        max_name_col = max(len(f.name) for f in fields)
+    max_type = max((len(f.type_ann) for f in fields if f.type_ann), default=0)
 
     result = []
-    for line, p in zip(lines, parsed):
-        if p is None:
+    for line, field in zip(lines, parsed):
+        if field is None:
             result.append(line)
             continue
 
-        parts = [p["indent"]]
+        parts = [field.indent]
 
-        if has_types and p["has_colon"]:
-            name_colon = p["name"] + ":"
-            parts.append(name_colon.ljust(max_name_col))
+        if has_types and field.has_colon:
+            parts.append((field.name + ":").ljust(max_name_col))
             parts.append(" ")
-            parts.append(p["type"].ljust(max_type) if p["type"] else " " * max_type)
-        elif has_types and not p["has_colon"]:
-            parts.append(p["name"].ljust(max_name_col))
+            parts.append(field.type_ann.ljust(max_type) if field.type_ann else " " * max_type)
+        elif has_types:
+            parts.append(field.name.ljust(max_name_col))
             parts.append(" " * (max_type + 1))
         else:
-            parts.append(p["name"].ljust(max_name_col))
+            parts.append(field.name.ljust(max_name_col))
 
-        if has_defaults and p["default"]:
-            parts.append(" " * MIN_GAP + "= " + p["default"])
+        if has_defaults and field.default:
+            parts.append(" " * MIN_GAP + "= " + field.default)
 
-        if has_comments and p["comment"]:
+        if has_comments and field.comment:
             so_far = "".join(parts).rstrip()
-            parts = [so_far]
-            parts.append(" " * MIN_GAP + " " + p["comment"])
+            parts = [so_far, " " * MIN_GAP + " " + field.comment]
 
         rebuilt = "".join(parts).rstrip()
-        result.append(rebuilt + "\n" if line.endswith("\n") else rebuilt)
+        nl = "\n" if line.endswith("\n") else ""
+        result.append(rebuilt + nl)
 
     return result
 
 
-def process_file(path: Path, check: bool = False) -> bool:
-    """Process one file. Returns True if file is aligned (or was fixed)."""
+# --- File processing ---
+
+
+def process_file(path: Path, *, check: bool = False) -> bool:
+    """Align all ``# fmt: off`` blocks in a single file.
+
+    Args:
+        path: Python source file to process.
+        check: If True, report misalignment without modifying the file.
+
+    Returns:
+        True if the file is already aligned (or was successfully fixed).
+
+    """
     text = path.read_text()
     lines = text.splitlines(keepends=True)
-
-    in_fmt_off = False
-    block_start = -1
     new_lines = list(lines)
     changed = False
 
     i = 0
+    block_start = -1
+    in_block = False
+
     while i < len(lines):
         stripped = lines[i].strip()
 
         if stripped == "# fmt: off":
-            in_fmt_off = True
+            in_block = True
             block_start = i + 1
-            i += 1
-            continue
-
-        if stripped == "# fmt: on" and in_fmt_off:
-            in_fmt_off = False
+        elif stripped == "# fmt: on" and in_block:
+            in_block = False
             block = lines[block_start:i]
-            aligned = _align_block(block)
+            aligned = align_block(block)
             if aligned != block:
                 changed = True
                 new_lines[block_start:i] = aligned
-            i += 1
-            continue
-
         i += 1
 
     if not changed:
         return True
-
     if check:
         return False
 
@@ -251,14 +269,19 @@ def process_file(path: Path, check: bool = False) -> bool:
     return True
 
 
-def main() -> int:
-    args = sys.argv[1:]
-    check = "--check" in args
-    args = [a for a in args if a != "--check"]
+def collect_paths(args: list[str]) -> list[Path]:
+    """Resolve CLI arguments into a sorted list of Python file paths.
 
-    if not args:
-        args = ["src/"]
+    Args:
+        args: File or directory paths from the command line.
 
+    Returns:
+        Sorted list of ``.py`` file paths.
+
+    Raises:
+        SystemExit: If a path does not exist.
+
+    """
     paths: list[Path] = []
     for arg in args:
         p = Path(arg)
@@ -268,24 +291,29 @@ def main() -> int:
             paths.append(p)
         else:
             print(f"Not found: {arg}", file=sys.stderr)
-            return 1
+            raise SystemExit(1)
+    return sorted(paths)
 
-    misaligned = []
-    for path in sorted(paths):
-        ok = process_file(path, check=check)
-        if not ok:
-            misaligned.append(path)
+
+def main() -> int:
+    """Entry point for the align-fields formatter.
+
+    Returns:
+        0 on success, 1 if misaligned files found in check mode.
+
+    """
+    argv = sys.argv[1:]
+    check = "--check" in argv
+    args = [a for a in argv if a != "--check"] or ["src/"]
+
+    paths = collect_paths(args)
+    misaligned = [p for p in paths if not process_file(p, check=check)]
 
     if check and misaligned:
         for p in misaligned:
             print(f"MISALIGNED: {p}")
-        print(f"\nRun: python scripts/align-fields.py")
+        print("\nRun: python scripts/align-fields.py")
         return 1
-
-    if not check and misaligned:
-        # This shouldn't happen (we fixed them), but just in case
-        for p in misaligned:
-            print(f"Fixed: {p}")
 
     return 0
 

--- a/scripts/align-fields.py
+++ b/scripts/align-fields.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Align dataclass/enum fields inside ``# fmt: off`` blocks.
+
+Scans Python files for ``# fmt: off`` / ``# fmt: on`` regions and
+column-aligns assignment lines so that field names, type annotations,
+default values, and inline comments line up.
+
+Usage:
+    scripts/align-fields.py                    # fix all src/ files in place
+    scripts/align-fields.py --check            # exit 1 if anything is misaligned
+    scripts/align-fields.py src/wingman/tools.py  # fix specific files
+    scripts/align-fields.py --check src/       # check a directory
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Matches lines like:  name: type = default  # comment
+#   or:                 NAME = ("value", ...)
+FIELD_RE = re.compile(
+    r"^(?P<indent>\s+)"
+    r"(?P<name>\w+)"
+    r"(?P<colon>:\s*)?(?P<type>[^=#]+?)?"
+    r"(?P<eq>\s*=\s*)?"
+    r"(?P<default>.+?)?"
+    r"(?P<comment>\s*#\s*.+)?"
+    r"$"
+)
+
+MIN_GAP = 2
+
+
+def _is_field_line(line: str) -> bool:
+    """Heuristic: line is a dataclass field or enum member assignment."""
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or stripped.startswith("def "):
+        return False
+    if stripped.startswith("@") or stripped.startswith("class "):
+        return False
+    if stripped.startswith(("\"\"\"", "'''", ")", "]", "}")):
+        return False
+    # Must have either `: type` or `= value`
+    return ":" in stripped or "=" in stripped
+
+
+def _parse_field(line: str) -> dict | None:
+    """Parse a field line into parts for alignment."""
+    stripped = line.strip()
+    if not _is_field_line(line):
+        return None
+
+    indent = line[: len(line) - len(line.lstrip())]
+
+    # Split off trailing inline comment
+    comment = ""
+    in_str = False
+    str_char = ""
+    paren_depth = 0
+    comment_start = -1
+    for i, ch in enumerate(stripped):
+        if in_str:
+            if ch == str_char and (i == 0 or stripped[i - 1] != "\\"):
+                in_str = False
+        elif ch in ('"', "'"):
+            in_str = True
+            str_char = ch
+        elif ch in ("(", "[", "{"):
+            paren_depth += 1
+        elif ch in (")", "]", "}"):
+            paren_depth -= 1
+        elif ch == "#" and paren_depth == 0:
+            comment_start = i
+            break
+
+    if comment_start >= 0:
+        comment = stripped[comment_start:]
+        stripped = stripped[:comment_start].rstrip()
+
+    # Parse name: type = default
+    if ":" in stripped:
+        colon_idx = stripped.index(":")
+        name = stripped[:colon_idx].strip()
+        rest = stripped[colon_idx + 1:].strip()
+
+        if "=" in rest:
+            # Find top-level `=` (not inside parens/brackets)
+            eq_idx = _find_top_level_eq(rest)
+            if eq_idx is not None:
+                type_ann = rest[:eq_idx].strip()
+                default = rest[eq_idx + 1:].strip()
+            else:
+                type_ann = rest
+                default = ""
+        else:
+            type_ann = rest
+            default = ""
+
+        return {
+            "indent": indent,
+            "name": name,
+            "type": type_ann,
+            "default": default,
+            "comment": comment,
+            "has_colon": True,
+        }
+
+    elif "=" in stripped:
+        eq_idx = _find_top_level_eq(stripped)
+        if eq_idx is None:
+            return None
+        name = stripped[:eq_idx].strip()
+        default = stripped[eq_idx + 1:].strip()
+        return {
+            "indent": indent,
+            "name": name,
+            "type": "",
+            "default": default,
+            "comment": comment,
+            "has_colon": False,
+        }
+
+    return None
+
+
+def _find_top_level_eq(s: str) -> int | None:
+    """Find the first `=` not inside parens/brackets/strings."""
+    depth = 0
+    in_str = False
+    str_char = ""
+    for i, ch in enumerate(s):
+        if in_str:
+            if ch == str_char and (i == 0 or s[i - 1] != "\\"):
+                in_str = False
+        elif ch in ('"', "'"):
+            in_str = True
+            str_char = ch
+        elif ch in ("(", "[", "{"):
+            depth += 1
+        elif ch in (")", "]", "}"):
+            depth -= 1
+        elif ch == "=" and depth == 0:
+            # Skip == and !=
+            if i + 1 < len(s) and s[i + 1] == "=":
+                continue
+            if i > 0 and s[i - 1] in ("!", "<", ">"):
+                continue
+            return i
+    return None
+
+
+def _align_block(lines: list[str]) -> list[str]:
+    """Align a group of consecutive field lines."""
+    parsed = []
+    for line in lines:
+        p = _parse_field(line)
+        if p:
+            parsed.append(p)
+        else:
+            parsed.append(None)
+
+    fields = [p for p in parsed if p is not None]
+    if len(fields) < 2:
+        return lines
+
+    has_types = any(f["has_colon"] for f in fields)
+    has_defaults = any(f["default"] for f in fields)
+    has_comments = any(f["comment"] for f in fields)
+
+    # name+colon is one visual unit: "name:" then space then type
+    if has_types:
+        max_name_col = max(len(f["name"]) + 1 for f in fields if f["has_colon"])
+    else:
+        max_name_col = max(len(f["name"]) for f in fields)
+    max_type = max((len(f["type"]) for f in fields if f["type"]), default=0)
+
+    result = []
+    for line, p in zip(lines, parsed):
+        if p is None:
+            result.append(line)
+            continue
+
+        parts = [p["indent"]]
+
+        if has_types and p["has_colon"]:
+            name_colon = p["name"] + ":"
+            parts.append(name_colon.ljust(max_name_col))
+            parts.append(" ")
+            parts.append(p["type"].ljust(max_type) if p["type"] else " " * max_type)
+        elif has_types and not p["has_colon"]:
+            parts.append(p["name"].ljust(max_name_col))
+            parts.append(" " * (max_type + 1))
+        else:
+            parts.append(p["name"].ljust(max_name_col))
+
+        if has_defaults and p["default"]:
+            parts.append(" " * MIN_GAP + "= " + p["default"])
+
+        if has_comments and p["comment"]:
+            so_far = "".join(parts).rstrip()
+            parts = [so_far]
+            parts.append(" " * MIN_GAP + " " + p["comment"])
+
+        rebuilt = "".join(parts).rstrip()
+        result.append(rebuilt + "\n" if line.endswith("\n") else rebuilt)
+
+    return result
+
+
+def process_file(path: Path, check: bool = False) -> bool:
+    """Process one file. Returns True if file is aligned (or was fixed)."""
+    text = path.read_text()
+    lines = text.splitlines(keepends=True)
+
+    in_fmt_off = False
+    block_start = -1
+    new_lines = list(lines)
+    changed = False
+
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+
+        if stripped == "# fmt: off":
+            in_fmt_off = True
+            block_start = i + 1
+            i += 1
+            continue
+
+        if stripped == "# fmt: on" and in_fmt_off:
+            in_fmt_off = False
+            block = lines[block_start:i]
+            aligned = _align_block(block)
+            if aligned != block:
+                changed = True
+                new_lines[block_start:i] = aligned
+            i += 1
+            continue
+
+        i += 1
+
+    if not changed:
+        return True
+
+    if check:
+        return False
+
+    path.write_text("".join(new_lines))
+    return True
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    check = "--check" in args
+    args = [a for a in args if a != "--check"]
+
+    if not args:
+        args = ["src/"]
+
+    paths: list[Path] = []
+    for arg in args:
+        p = Path(arg)
+        if p.is_dir():
+            paths.extend(p.rglob("*.py"))
+        elif p.is_file():
+            paths.append(p)
+        else:
+            print(f"Not found: {arg}", file=sys.stderr)
+            return 1
+
+    misaligned = []
+    for path in sorted(paths):
+        ok = process_file(path, check=check)
+        if not ok:
+            misaligned.append(path)
+
+    if check and misaligned:
+        for p in misaligned:
+            print(f"MISALIGNED: {p}")
+        print(f"\nRun: python scripts/align-fields.py")
+        return 1
+
+    if not check and misaligned:
+        # This shouldn't happen (we fixed them), but just in case
+        for p in misaligned:
+            print(f"Fixed: {p}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

Adds a column-alignment formatter for dataclass fields and enum members inside `# fmt: off` blocks. This prettifies field names, types, defaults, and comments to be column-aligned.

**New files:**
- `scripts/align-fields.py` — formatter with `--check` mode for CI
- `prek.toml` — local hooks for align-fields, ruff check, ruff format

**Usage:**
```bash
# Install git hooks
prek install

# Run manually
python scripts/align-fields.py              # fix all src/ files
python scripts/align-fields.py --check      # check only (CI mode)
prek run --all-files                        # run all hooks
```

**Example output:**
```python
# fmt: off
@dataclass(slots=True)
class BackgroundProcess:
    pid:           int                         # OS process ID.
    command:       str                         # Shell command.
    process:       asyncio.subprocess.Process  # Async handle.
    output_buffer: list[str]                   = field(default_factory=list)
    started_at:    float                       = field(default_factory=time.time)
# fmt: on
```

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have tested the TUI locally