### PR TITLE
fix(ui): keep slash command hint visible on exact match

### DIFF
--- a/src/wingman/command_completion.py
+++ b/src/wingman/command_completion.py
@@ -152,8 +152,6 @@ def get_hint_candidates(
             for cmd, desc in COMMANDS
             if search_lower in cmd.lower() or search_lower in desc.lower()
         ]
-        if len(matches) == 1 and matches[0].lstrip("/") == search:
-            return []
         return matches
 
     if context.active_index == 1:
@@ -161,15 +159,10 @@ def get_hint_candidates(
         if not options:
             return []
         prefix = context.active.text
-        matches = _match_options(prefix, options)
-        if len(matches) == 1 and matches[0] == prefix:
-            return []
-        return matches
+        return _match_options(prefix, options)
 
     dynamic = _get_dynamic_matches(context, value, cursor_position, candidate_provider)
     if dynamic:
-        if len(dynamic) == 1 and dynamic[0] == context.active.text:
-            return []
         return dynamic
 
     return []


### PR DESCRIPTION
## Description

Typing a full command like `/bug` would hide the autocomplete hint because `get_hint_candidates` returned `[]` when a single match equaled the input exactly. The hint should stay visible to confirm the command is valid.

Removed the "hide on exact match" early-return in all three hint candidate paths (commands, options, dynamic).

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have tested the TUI locally
