### PR TITLE
feat: add BASE_URL env var for custom API endpoints

### DIFF
--- a/src/wingman/app.py
+++ b/src/wingman/app.py
@@ -25,6 +25,7 @@ from .config import (
     MODELS,
     fetch_marketplace_servers,
     load_api_key,
+    load_base_url,
     load_instructions,
 )
 from .context import AUTO_COMPACT_THRESHOLD
@@ -102,7 +103,11 @@ class WingmanApp(App):
 
     def _init_client(self, api_key: str) -> None:
         """Initialize Dedalus client with API key."""
-        self.client = AsyncDedalus(api_key=api_key)
+        base_url = load_base_url()
+        kwargs: dict = {"api_key": api_key}
+        if base_url:
+            kwargs["base_url"] = base_url
+        self.client = AsyncDedalus(**kwargs)
         self.runner = DedalusRunner(self.client)
 
     @property
@@ -213,7 +218,9 @@ class WingmanApp(App):
             cwd_display = str(cwd)
         cwd_text = f" │ [dim]{escape(cwd_display)}[/]"
 
-        status = f"{session_text} │ {model_short}{code_text}{generating_text}{memory_text}{img_text}{mcp_text}{ctx_text}{panel_text}{cwd_text}"
+        base_url = load_base_url()
+        base_text = f" │ [#e0af68]{base_url.split('//')[1][:30]}[/]" if base_url else ""
+        status = f"{session_text} │ {model_short}{base_text}{code_text}{generating_text}{memory_text}{img_text}{mcp_text}{ctx_text}{panel_text}{cwd_text}"
         self.query_one("#status", Static).update(Text.from_markup(status))
 
     def _refresh_sessions(self) -> None:

--- a/src/wingman/config.py
+++ b/src/wingman/config.py
@@ -134,6 +134,33 @@ def load_api_key() -> str | None:
     return None
 
 
+def load_base_url() -> str | None:
+    """Load API base URL from environment or config.
+
+    Checks ``WINGMAN_BASE_URL`` env var first, then ``base_url`` in
+    ``~/.wingman/config.json``. Returns None to use the SDK default.
+
+    Returns:
+        Base URL string or None.
+
+    """
+    import os
+
+    env_url = os.environ.get("WINGMAN_BASE_URL")
+    if env_url:
+        return env_url.rstrip("/")
+
+    if CONFIG_FILE.exists():
+        try:
+            config = oj.loads(CONFIG_FILE.read_text())
+            url = config.get("base_url")
+            if url:
+                return url.rstrip("/")
+        except Exception:
+            pass
+    return None
+
+
 def save_api_key(api_key: str) -> None:
     """Save API key to config file."""
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)

--- a/src/wingman/config.py
+++ b/src/wingman/config.py
@@ -137,7 +137,7 @@ def load_api_key() -> str | None:
 def load_base_url() -> str | None:
     """Load API base URL from environment or config.
 
-    Checks ``WINGMAN_BASE_URL`` env var first, then ``base_url`` in
+    Checks ``BASE_URL`` env var first, then ``base_url`` in
     ``~/.wingman/config.json``. Returns None to use the SDK default.
 
     Returns:
@@ -146,7 +146,7 @@ def load_base_url() -> str | None:
     """
     import os
 
-    env_url = os.environ.get("WINGMAN_BASE_URL")
+    env_url = os.environ.get("BASE_URL")
     if env_url:
         return env_url.rstrip("/")
 

--- a/src/wingman/headless.py
+++ b/src/wingman/headless.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from dedalus_labs import AsyncDedalus, DedalusRunner
 
-from .config import MODELS, load_api_key, load_instructions
+from .config import MODELS, load_api_key, load_base_url, load_instructions
 from .tools import CODING_SYSTEM_PROMPT, create_tools_headless
 
 
@@ -43,7 +43,11 @@ async def run_headless(
         model = MODELS[0]
 
     try:
-        client = AsyncDedalus(api_key=api_key)
+        base_url = load_base_url()
+        kwargs: dict = {"api_key": api_key}
+        if base_url:
+            kwargs["base_url"] = base_url
+        client = AsyncDedalus(**kwargs)
         runner = DedalusRunner(client)
 
         # Build system prompt

--- a/src/wingman/ui/modals.py
+++ b/src/wingman/ui/modals.py
@@ -12,7 +12,7 @@ from textual.containers import Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Input, Label, ListItem, ListView, Static
 
-from ..config import save_api_key
+from ..config import load_base_url, save_api_key
 
 
 class APIKeyScreen(ModalScreen[str | None]):
@@ -54,7 +54,11 @@ class APIKeyScreen(ModalScreen[str | None]):
         status.set_classes("validating")
 
         try:
-            client = AsyncDedalus(api_key=key)
+            base_url = load_base_url()
+            kwargs: dict = {"api_key": key}
+            if base_url:
+                kwargs["base_url"] = base_url
+            client = AsyncDedalus(**kwargs)
             await client.models.list()
             save_api_key(key)
             self.dismiss(key)


### PR DESCRIPTION
## Description

Adds support for pointing wingman at any OpenAI-compatible API endpoint via the `BASE_URL` environment variable.

```bash
BASE_URL=https://preview.api.dedaluslabs.ai wingman
```

Also supports `base_url` in `~/.wingman/config.json` as a persistent alternative.

When a custom base URL is active, the status bar shows the endpoint hostname so it's obvious you're not hitting production.

Applied to all three client init paths: TUI, headless mode, and API key validation.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have tested the TUI locally